### PR TITLE
docs: block ChatGPT, Claude and Gemini bots

### DIFF
--- a/docs/cookbook/server/block_chatgpt_claude_gemini.md
+++ b/docs/cookbook/server/block_chatgpt_claude_gemini.md
@@ -1,0 +1,46 @@
+---
+title: Блокировка ботов ChatGPT, Claude и Gemini
+icon: fa-solid fa-robot
+category: Поисковые боты
+tag: [боты, ChatGPT, Claude, Gemini, robots.txt, htaccess]
+---
+
+# Блокировка ботов ChatGPT, Claude и Gemini
+
+## Зачем блокировать
+
+Генеративные ИИ‑платформы активно сканируют сайты для обучения своих моделей. Если не ограничить доступ, боты могут создавать ненужную нагрузку и использовать ваш контент без разрешения. Ниже приведены простые инструкции, как отключить доступ GPTBot, ClaudeBot и Google‑Extended.
+
+## robots.txt
+
+```robots.txt
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+```
+
+## .htaccess
+
+```apacheconf
+# Блокировка ChatGPT, Claude и Gemini
+SetEnvIfNoCase User-Agent "GPTBot" bad_bot
+SetEnvIfNoCase User-Agent "ClaudeBot" bad_bot
+SetEnvIfNoCase User-Agent "Claude-Web" bad_bot
+SetEnvIfNoCase User-Agent "Google-Extended" bad_bot
+
+<Limit GET POST HEAD>
+  Order Allow,Deny
+  Allow from all
+  Deny from env=bad_bot
+</Limit>
+```
+
+Эти правила не позволят указанным ботам получать содержимое сайта, что поможет уменьшить нагрузку на сервер и исключить использование ваших материалов при обучении моделей.
+
+Также смотрите статью [Поисковые боты OpenAI](/cookbook/server/chatgpt_bot) для подробностей о других роботах.

--- a/docs/cookbook/server/chatgpt_bot.md
+++ b/docs/cookbook/server/chatgpt_bot.md
@@ -40,7 +40,7 @@ Disallow: /directory-2/
 
 Ну и на закуску - бот судя по всему игнорирует директиву Crawl-delay. Так как у меня стоит ограничение 1 запрос в минуту, а запросов от GPTBot было более 50к за сутки.
 
-В принципе его можно заблокировать, как [AmazonBot](/cookbook/server/amazon_bot). Нужно прописать в .htaccess:
+В принципе его можно заблокировать, как [AmazonBot](/cookbook/server/amazon_bot) или воспользоваться готовыми [правилами для блокировки ChatGPT, Claude и Gemini](/cookbook/server/block_chatgpt_claude_gemini). Нужно прописать в .htaccess:
 
 ```apacheconf
 #Блокировка User-Agent "Chat"


### PR DESCRIPTION
## Summary
- add server cookbook article on blocking GPTBot, ClaudeBot and Google-Extended crawlers using robots.txt and .htaccess
- cross-link the new recipe with the OpenAI bots article for easier navigation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a12a47c308325961ae975e457c34e