### PR TITLE
docs: add swap management script

### DIFF
--- a/docs/cookbook/server/debian_ubuntu_swap.md
+++ b/docs/cookbook/server/debian_ubuntu_swap.md
@@ -1,0 +1,123 @@
+---
+title: Добавление swap в Debian/Ubuntu
+icon: fa-solid fa-memory
+category: Linux
+tag: [Linux, swap, Debian, Ubuntu]
+---
+
+Самая дешёвая VDS часто имеет всего 512 МБ или 1 ГБ оперативной памяти. Для некоторых задач, например сборки npm-зависимостей, этого недостаточно. Swap позволяет расширить доступную память за счёт диска.
+
+## Вариант 1. Swap-файл
+
+1. Проверим, есть ли уже swap:
+
+```bash
+swapon --show
+free -h
+```
+
+Если вывод пустой — swap не настроен.
+
+2. Создадим файл (например, на 2 ГиБ):
+
+```bash
+sudo fallocate -l 2G /swapfile
+```
+
+Если `fallocate` недоступен:
+
+```bash
+sudo dd if=/dev/zero of=/swapfile bs=1M count=2048 status=progress
+```
+
+3. Выставим права:
+
+```bash
+sudo chmod 600 /swapfile
+```
+
+4. Разметим файл подкачки:
+
+```bash
+sudo mkswap /swapfile
+```
+
+5. Включим swap:
+
+```bash
+sudo swapon /swapfile
+```
+
+6. Проверим:
+
+```bash
+swapon --show
+free -h
+```
+
+7. Чтобы swap подключался при загрузке, добавим строку в `/etc/fstab`:
+
+```bash
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
+## Вариант 2. Отдельный раздел
+
+1. Определим раздел:
+
+```bash
+lsblk
+```
+
+Например, `/dev/sdb2`.
+
+2. Разметим его как swap:
+
+```bash
+sudo mkswap /dev/sdb2
+```
+
+3. Активируем:
+
+```bash
+sudo swapon /dev/sdb2
+```
+
+4. Для автоподключения добавим строку в `/etc/fstab`:
+
+```bash
+echo '/dev/sdb2 none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
+## Дополнительно
+
+### Настройка swappiness
+
+Параметр `swappiness` определяет, как активно система будет использовать swap. Проверить текущее значение:
+
+```bash
+cat /proc/sys/vm/swappiness
+```
+
+Чтобы система реже обращалась к swap, можно установить значение 10:
+
+```bash
+echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
+```
+### Скрипт `swapctl`
+
+Для автоматизации настройки в репозитории есть idempotent‑скрипт `swapctl.sh`. Он создаёт или удаляет swap‑файлы, настраивает `vm.swappiness` и прописывает запись в `/etc/fstab`.
+
+Запуск в одну строку прямо с GitHub:
+
+```bash
+sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --size 4G --swappiness 10
+```
+
+Другие примеры:
+
+```bash
+sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --file /swap2 --size 1536M
+sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --remove
+sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --help
+```

--- a/scripts/swapctl.sh
+++ b/scripts/swapctl.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# swapctl.sh — создать/удалить swap-файл и настроить swappiness
+# Использование:
+#   sudo ./swapctl.sh --size 4G              # создать /swapfile на 4 ГиБ
+#   sudo ./swapctl.sh --size 2048M --file /swap2 # произвольный путь/размер
+#   sudo ./swapctl.sh --swappiness 10        # выставить swappiness (и сейчас, и постоянно)
+#   sudo ./swapctl.sh --remove               # отключить и удалить /swapfile (или --file ...)
+#
+# Параметры по умолчанию:
+#   --file /swapfile
+#   --size 2G
+#   --swappiness (не меняем, если не указано)
+
+set -euo pipefail
+
+FILE="/swapfile"
+SIZE="2G"
+SWAPPINESS=""
+DO_REMOVE="0"
+
+usage() {
+  sed -n 's/^# //p; /^$/q' "$0"
+  exit 1
+}
+
+# --- Парсим аргументы ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--file) FILE="${2:-}"; shift 2;;
+    -s|--size) SIZE="${2:-}"; shift 2;;
+    --swappiness) SWAPPINESS="${2:-}"; shift 2;;
+    -r|--remove) DO_REMOVE="1"; shift;;
+    -h|--help) usage;;
+    *) echo "Неизвестный аргумент: $1"; usage;;
+  esac
+done
+
+# --- Утилиты/проверки ---
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "Запустите с sudo/от root."
+    exit 1
+  fi
+}
+
+in_fstab() {
+  local esc
+  esc="$(printf '%s' "$FILE" | sed 's/[.[\*^$()+?{|}/]/\\&/g')"
+  grep -Eq "^${esc}[[:space:]]+none[[:space:]]+swap[[:space:]]" /etc/fstab 2>/dev/null || return 1
+}
+
+remove_fstab() {
+  local esc
+  esc="$(printf '%s' "$FILE" | sed 's/[.[\*^$()+?{|}/]/\\&/g')"
+  if in_fstab; then
+    sed -i.bak "/^${esc}[[:space:]]\+none[[:space:]]\+swap[[:space:]]/d" /etc/fstab
+  fi
+}
+
+parse_size_to_mib() {
+  local s="${1^^}"
+  if [[ "$s" =~ ^([0-9]+)G$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 1024 ))
+  elif [[ "$s" =~ ^([0-9]+)M$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} ))
+  elif [[ "$s" =~ ^[0-9]+$ ]]; then
+    echo "$s"
+  else
+    echo "Неверный формат размера: $1 (ожидается, например, 4G или 4096M)" >&2
+    exit 1
+  fi
+}
+
+create_swapfile() {
+  local mib="$1"
+
+  if [[ -e "$FILE" ]]; then
+    if file -L "$FILE" | grep -qi 'swap'; then
+      echo "Файл $FILE уже существует и похож на swap. Пропускаю создание."
+    else
+      echo "Файл $FILE существует. Пропускаю создание, попробую использовать его как swap."
+    fi
+  else
+    if command -v fallocate >/dev/null 2>&1; then
+      fallocate -l "$((mib))MiB" "$FILE" 2>/dev/null || {
+        echo "fallocate недоступен/не поддерживается на FS, пробую dd..."
+        dd if=/dev/zero of="$FILE" bs=1M count="$mib" status=progress
+      }
+    else
+      dd if=/dev/zero of="$FILE" bs=1M count="$mib" status=progress
+    fi
+  fi
+
+  chmod 600 "$FILE"
+  mkswap "$FILE" >/dev/null
+  swapon "$FILE" || true
+
+  if ! in_fstab; then
+    echo -e "${FILE}\tnone\tswap\tsw\t0 0" >> /etc/fstab
+  fi
+  echo "Готово: активирован swap ${mib}MiB в $FILE"
+}
+
+remove_swapfile() {
+  swapoff "$FILE" 2>/dev/null || true
+  remove_fstab
+  if [[ -e "$FILE" ]]; then
+    rm -f "$FILE"
+    echo "Удалён $FILE и запись из /etc/fstab."
+  else
+    echo "Файл $FILE не найден. Убрана возможная запись из /etc/fstab."
+  fi
+}
+
+set_swappiness() {
+  local val="$1"
+  if [[ -z "$val" ]]; then return 0; fi
+  if ! [[ "$val" =~ ^[0-9]+$ ]] || (( val < 0 || val > 200 )); then
+    echo "Некорректный swappiness: $val (ожидается 0..200)" >&2
+    exit 1
+  fi
+
+  sysctl vm.swappiness="$val" >/dev/null
+
+  local conf="/etc/sysctl.d/99-swapctl.conf"
+  mkdir -p /etc/sysctl.d
+  echo "vm.swappiness=$val" > "$conf"
+  sysctl --system >/dev/null
+  echo "Установлен vm.swappiness=$val (и применён постоянно)."
+}
+
+main() {
+  require_root
+  if [[ "$DO_REMOVE" == "1" ]]; then
+    remove_swapfile
+    exit 0
+  fi
+
+  local mib
+  mib="$(parse_size_to_mib "$SIZE")"
+
+  if swapon --show | grep -q .; then
+    echo "Внимание: в системе уже активен swap. Будет добавлен ещё один."
+  fi
+
+  create_swapfile "$mib"
+
+  if [[ -n "$SWAPPINESS" ]]; then
+    set_swappiness "$SWAPPINESS"
+  fi
+
+  echo
+  echo "Текущее состояние:"
+  swapon --show || true
+  free -h || true
+}
+
+main "$@"
+


### PR DESCRIPTION
## Summary
- add `swapctl.sh` script to create/remove swap files and configure swappiness
- document one-line GitHub usage with raw link to `swapctl.sh` in Debian/Ubuntu swap guide
- move `swapctl.sh` to top-level `scripts/` directory for cleaner raw URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build` *(fails: vuepress-vite: not found)*
- `npm ci` *(fails: could not resolve dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a5424d6a3483259c0b6eff6c9effcf