### PR TITLE
fix: run swapctl via pipe and improve help

### DIFF
--- a/docs/cookbook/server/debian_ubuntu_swap.md
+++ b/docs/cookbook/server/debian_ubuntu_swap.md
@@ -111,13 +111,13 @@ echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
 Запуск в одну строку прямо с GitHub:
 
 ```bash
-sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --size 4G --swappiness 10
+curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh | sudo bash -s -- --size 4G --swappiness 10
 ```
 
 Другие примеры:
 
 ```bash
-sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --file /swap2 --size 1536M
-sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --remove
-sudo bash <(curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh) --help
+curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh | sudo bash -s -- --file /swap2 --size 1536M
+curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh | sudo bash -s -- --remove
+curl -fsSL https://raw.githubusercontent.com/Ichinya/seo_recipes/main/scripts/swapctl.sh | sudo bash -s -- --help
 ```

--- a/scripts/swapctl.sh
+++ b/scripts/swapctl.sh
@@ -19,7 +19,19 @@ SWAPPINESS=""
 DO_REMOVE="0"
 
 usage() {
-  sed -n 's/^# //p; /^$/q' "$0"
+  cat <<'EOF'
+swapctl.sh — создать/удалить swap-файл и настроить swappiness
+Использование:
+  sudo ./swapctl.sh --size 4G              # создать /swapfile на 4 ГиБ
+  sudo ./swapctl.sh --size 2048M --file /swap2 # произвольный путь/размер
+  sudo ./swapctl.sh --swappiness 10        # выставить swappiness (и сейчас, и постоянно)
+  sudo ./swapctl.sh --remove               # отключить и удалить /swapfile (или --file ...)
+
+Параметры по умолчанию:
+  --file /swapfile
+  --size 2G
+  --swappiness (не меняем, если не указано)
+EOF
   exit 1
 }
 


### PR DESCRIPTION
## Summary
- fix swapctl help output to work when piped to bash
- document piping script to sudo bash instead of process substitution

## Testing
- `cat scripts/swapctl.sh | bash -s -- --help`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a56cee6b788325a4da899b792fe3f9