### PR TITLE
Добавить Google-CloudVertexBot и уточнить управление AI crawler

### DIFF
--- a/docs/hosting/scripts/block_chatgpt_claude_gemini.md
+++ b/docs/hosting/scripts/block_chatgpt_claude_gemini.md
@@ -1,46 +1,190 @@
 ---
-title: Блокировка ботов ChatGPT, Claude и Gemini
+title: Управление доступом ботов ChatGPT, Claude и Google AI
 icon: fa-solid fa-robot
 category: Поисковые боты
-tag: [боты, ChatGPT, Claude, Gemini, robots.txt, htaccess]
+tag: [боты, ChatGPT, Claude, Gemini, Google-CloudVertexBot, Google-Extended, robots.txt, htaccess]
 ---
 
-# Блокировка ботов ChatGPT, Claude и Gemini
+# Управление доступом ботов ChatGPT, Claude и Google AI
 
-## Зачем блокировать
+У разных AI-сервисов разные механизмы доступа к сайту. Нельзя считать, что все названия из `robots.txt` являются реальными HTTP User-Agent строками.
 
-Генеративные ИИ‑платформы активно сканируют сайты для обучения своих моделей. Если не ограничить доступ, боты могут создавать ненужную нагрузку и использовать ваш контент без разрешения. Ниже приведены простые инструкции, как отключить доступ GPTBot, ClaudeBot и Google‑Extended.
+Особенно важно различать:
+
+- `GPTBot` и `ClaudeBot` — crawler'ы с HTTP User-Agent;
+- `Google-CloudVertexBot` — crawler Google для Agent Search / Vertex AI сценариев;
+- `Google-Extended` — product token для `robots.txt`, **без отдельной HTTP User-Agent строки**.
 
 ## robots.txt
+
+Пример запрета:
 
 ```robots.txt
 User-agent: GPTBot
 Disallow: /
 
 User-agent: ClaudeBot
-User-agent: Claude-Web
+Disallow: /
+
+User-agent: Google-CloudVertexBot
 Disallow: /
 
 User-agent: Google-Extended
 Disallow: /
 ```
 
-## .htaccess
+Это четыре разных политики.
 
-```apacheconf
-# Блокировка ChatGPT, Claude и Gemini
-SetEnvIfNoCase User-Agent "GPTBot" bad_bot
-SetEnvIfNoCase User-Agent "ClaudeBot" bad_bot
-SetEnvIfNoCase User-Agent "Claude-Web" bad_bot
-SetEnvIfNoCase User-Agent "Google-Extended" bad_bot
+### Google-CloudVertexBot
 
-<Limit GET POST HEAD>
-  Order Allow,Deny
-  Allow from all
-  Deny from env=bad_bot
-</Limit>
+Google представил `Google-CloudVertexBot` 20 августа 2026 года. Он обходит сайты по запросу владельца при построении Vertex AI / Agent Search.
+
+Его правила **не влияют на Google Search**.
+
+Подробнее: [Google-CloudVertexBot и Agent Search](../../info/google/google-cloudvertexbot.md).
+
+### Google-Extended
+
+`Google-Extended` — не отдельный HTTP crawler User-Agent. Google описывает его как product token для управления использованием контента некоторыми Gemini и Vertex AI сценариями.
+
+Правило:
+
+```robots.txt
+User-agent: Google-Extended
+Disallow: /
 ```
 
-Эти правила не позволят указанным ботам получать содержимое сайта, что поможет уменьшить нагрузку на сервер и исключить использование ваших материалов при обучении моделей.
+имеет смысл.
 
-Также смотрите статью [Поисковые боты OpenAI](./chatgpt_bot.md) для подробностей о других роботах.
+Но ловить строку `Google-Extended` в HTTP-заголовке через `.htaccess` или Nginx как будто это самостоятельный crawler — некорректная модель: Google не заявляет отдельного User-Agent с таким именем.
+
+## Apache / .htaccess
+
+Если нужна именно техническая HTTP-блокировка crawler'ов, фильтровать можно только реальные User-Agent строки.
+
+```apacheconf
+SetEnvIfNoCase User-Agent "GPTBot" bad_bot
+SetEnvIfNoCase User-Agent "ClaudeBot" bad_bot
+SetEnvIfNoCase User-Agent "Google-CloudVertexBot" bad_bot
+
+<RequireAll>
+    Require all granted
+    Require not env bad_bot
+</RequireAll>
+```
+
+`Google-Extended` здесь намеренно отсутствует.
+
+Для старого Apache 2.2 синтаксис будет отличаться, но использовать устаревшие `Order Allow,Deny` без необходимости на современных конфигурациях не стоит.
+
+## Nginx
+
+```nginx
+map $http_user_agent $blocked_ai_bot {
+    default 0;
+    ~*GPTBot 1;
+    ~*ClaudeBot 1;
+    ~*Google-CloudVertexBot 1;
+}
+
+server {
+    if ($blocked_ai_bot) {
+        return 403;
+    }
+}
+```
+
+`if` в Nginx для простого `return` допустим, но для сложной логики лучше использовать WAF, `map` и отдельные location/rules.
+
+## robots.txt или HTTP 403
+
+Это разные уровни контроля.
+
+### robots.txt
+
+Подходит для добросовестных crawler'ов:
+
+- явно выражает политику владельца сайта;
+- не требует обработки правила на каждом endpoint;
+- проще сопровождать.
+
+### Firewall / WAF / Nginx / Apache
+
+Нужен, если запрос нужно технически отклонить независимо от поведения crawler'а.
+
+Минусы:
+
+- User-Agent легко подделать;
+- неправильный regex может зацепить обычных пользователей;
+- IP allowlist нужно поддерживать по официальным источникам;
+- можно случайно заблокировать crawler, который нужен другому продукту.
+
+## Не доверяйте одному User-Agent
+
+Строка:
+
+```text
+Google-CloudVertexBot
+```
+
+не является аутентификацией. Злоумышленник может отправить такой же заголовок.
+
+Если нужно подтвердить, что crawler действительно принадлежит Google, используйте официальную процедуру проверки crawler/fetcher и опубликованные Google IP ranges.
+
+## Отдельная политика для Search, обучения и Agent Search
+
+Пример:
+
+```robots.txt
+# Google Search разрешен
+User-agent: Googlebot
+Allow: /
+
+# Использование через Google-Extended запрещено
+User-agent: Google-Extended
+Disallow: /
+
+# Agent Search разрешен только для документации
+User-agent: Google-CloudVertexBot
+Allow: /docs/
+Disallow: /
+```
+
+Такое разделение гораздо безопаснее правила «заблокировать весь Google AI».
+
+## Sitemap и Agent Search
+
+Есть отдельная ловушка: страницы для Agent Search обходит `Google-CloudVertexBot`, а sitemap Google Cloud забирает через `Googlebot`.
+
+Если вы разрешили VertexBot, но запретили `Googlebot` доступ к sitemap, sitemap-based indexing/refresh не заработает как ожидается.
+
+Подробнее: [Google-CloudVertexBot и Agent Search](../../info/google/google-cloudvertexbot.md).
+
+## Что логировать
+
+Перед блокировкой полезно хотя бы неделю посмотреть реальный трафик:
+
+```bash
+grep -Ei 'GPTBot|ClaudeBot|Google-CloudVertexBot' /var/log/nginx/access.log
+```
+
+Смотрите не только количество запросов, но и:
+
+- какие URL обходятся;
+- HTTP status;
+- request time;
+- переданный трафик;
+- cache hit/miss;
+- частоту повторного обхода.
+
+Иногда правильнее ограничить конкретный раздел или rate limit, чем блокировать весь crawler.
+
+## Источники
+
+- [Google common crawlers](https://developers.google.com/crawling/docs/crawlers-fetchers/google-common-crawlers)
+- [Google crawler overview](https://developers.google.com/crawling/docs/crawlers-fetchers/overview-google-crawlers)
+- [Google Search documentation updates](https://developers.google.com/search/updates)
+- [OpenAI GPTBot documentation](https://platform.openai.com/docs/bots)
+- [Anthropic crawler documentation](https://support.anthropic.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler)
+
+Также смотрите [Поисковые боты OpenAI](./chatgpt_bot.md).

--- a/docs/hosting/scripts/user_agents.md
+++ b/docs/hosting/scripts/user_agents.md
@@ -1,14 +1,115 @@
 ---
-title: Подозрительные User Agents
+title: Подозрительные и служебные User Agents
 icon: fa-solid fa-user-secret
 category: Поисковые боты
-tag: [боты, user agent, malware]
+tag: [боты, user agent, malware, Google-CloudVertexBot, crawler]
 ---
 
-# Подозрительные User Agents
+# Подозрительные и служебные User Agents
 
-На GitHub наткнулся на список подозрительных User Agents. 
+На GitHub есть большой список подозрительных HTTP User-Agent строк:
 
-Вот ссылка на [список](https://github.com/mthcht/awesome-lists/blob/main/Lists/suspicious_http_user_agents_list.csv)
+- [mthcht/awesome-lists — suspicious_http_user_agents_list.csv](https://github.com/mthcht/awesome-lists/blob/main/Lists/suspicious_http_user_agents_list.csv)
 
-Может кому интересно будет. Хотел сюда выложить, но список большой и страница будет долго грузиться. Да и на GitHub по идее будет актуальный список.
+Дублировать весь список здесь нет смысла: он большой и быстрее устареет, чем исходный репозиторий.
+
+## User-Agent сам по себе ничего не доказывает
+
+Строку User-Agent может указать любой клиент.
+
+Например, запрос:
+
+```bash
+curl -A 'Googlebot' https://example.com/
+```
+
+не становится настоящим Googlebot только из-за заголовка.
+
+Поэтому нельзя использовать логику:
+
+```text
+известный User-Agent = доверенный запрос
+неизвестный User-Agent = злоумышленник
+```
+
+Для известных поисковых crawler'ов нужно использовать официальные методы проверки IP/reverse DNS или опубликованные диапазоны, если провайдер их предоставляет.
+
+## Не путать новый crawler с вредоносным трафиком
+
+20 августа 2026 года Google добавил новый crawler:
+
+```text
+Google-CloudVertexBot
+```
+
+Он используется для обхода сайтов по запросу владельца при построении Vertex AI / Agent Search.
+
+Если такая строка появилась в access log, это не повод автоматически отправлять её в blacklist.
+
+Подробнее: [Google-CloudVertexBot и Agent Search](../../info/google/google-cloudvertexbot.md).
+
+## Google-Extended — не HTTP User-Agent
+
+`Google-Extended` часто упоминается рядом с crawler'ами, но Google не заявляет отдельную HTTP User-Agent строку с этим именем.
+
+Это product token для `robots.txt`:
+
+```robots.txt
+User-agent: Google-Extended
+Disallow: /
+```
+
+Поэтому правило в WAF вида:
+
+```text
+HTTP User-Agent contains "Google-Extended"
+```
+
+не является эквивалентом `robots.txt`-политики Google-Extended.
+
+## Практический анализ access log
+
+Топ User-Agent строк в Nginx:
+
+```bash
+awk -F'"' '{print $6}' /var/log/nginx/access.log \
+  | sort \
+  | uniq -c \
+  | sort -nr \
+  | head -50
+```
+
+Поиск нескольких AI/crawler строк:
+
+```bash
+grep -Ei 'GPTBot|ClaudeBot|Google-CloudVertexBot|Googlebot' /var/log/nginx/access.log
+```
+
+При разборе подозрительного клиента полезно смотреть одновременно:
+
+- IP и ASN;
+- частоту запросов;
+- распределение URL;
+- HTTP methods;
+- status codes;
+- объем переданных данных;
+- request time;
+- соблюдение `robots.txt`;
+- официальную документацию владельца crawler'а.
+
+## Когда User-Agent действительно полезен
+
+Он удобен для:
+
+- аналитики crawler traffic;
+- отдельного логирования;
+- мягкого rate limiting;
+- диагностики;
+- применения официально поддерживаемой crawler-policy.
+
+Для защиты административных endpoint'ов, API и приватных данных User-Agent недостаточно. Нужны нормальная аутентификация, firewall/WAF и контроль доступа.
+
+## Связанные материалы
+
+- [Управление доступом ботов ChatGPT, Claude и Google AI](./block_chatgpt_claude_gemini.md)
+- [Google-CloudVertexBot и Agent Search](../../info/google/google-cloudvertexbot.md)

--- a/docs/info/google/google-cloudvertexbot.md
+++ b/docs/info/google/google-cloudvertexbot.md
@@ -1,0 +1,263 @@
+---
+title: Google-CloudVertexBot и Agent Search
+description: Как работает новый crawler Google для Vertex AI Agent Search, как управлять им через robots.txt и почему для sitemap нужен отдельный доступ Googlebot
+icon: fa-brands fa-google
+category: Google
+tag: [Google, Google-CloudVertexBot, Vertex AI, Agent Search, robots.txt, боты, AI]
+---
+
+# Google-CloudVertexBot и Agent Search
+
+20 августа 2026 года Google добавил `Google-CloudVertexBot` в официальный список crawler'ов. Он используется не обычным Google Search, а когда владелец сайта или приложения просит Google обходить сайт для построения Vertex AI / Agent Search.
+
+Это важное отличие: появление `Google-CloudVertexBot` в логах само по себе не означает изменение индекса Google Search и не связано напрямую с ранжированием.
+
+## Коротко
+
+| Что | Значение |
+| --- | --- |
+| User-Agent token | `Google-CloudVertexBot` |
+| Управление через `robots.txt` | Да |
+| Обычный Google Search | Не затрагивается |
+| Основной сценарий | Индексация сайта для Agent Search по запросу владельца |
+| Sitemap в Agent Search | Забирает обычный `Googlebot` |
+| Google-Extended | Отдельный product token, не тот же механизм |
+
+## Базовый robots.txt
+
+Разрешить обход:
+
+```robots.txt
+User-agent: Google-CloudVertexBot
+Allow: /
+```
+
+Закрыть весь сайт:
+
+```robots.txt
+User-agent: Google-CloudVertexBot
+Disallow: /
+```
+
+Разрешить только определенный раздел:
+
+```robots.txt
+User-agent: Google-CloudVertexBot
+Allow: /docs/
+Disallow: /
+```
+
+Google приводит аналогичный пример с выборочным доступом к разделам сайта.
+
+## Самый неочевидный момент: страницы и sitemap забирают разные crawler'ы
+
+Для Agent Search Google использует два разных механизма:
+
+```text
+страницы сайта
+    ↓
+Google-CloudVertexBot
+
+sitemap.xml
+    ↓
+Googlebot
+```
+
+Поэтому конфигурация вроде этой может работать не так, как ожидается:
+
+```robots.txt
+User-agent: Google-CloudVertexBot
+Allow: /
+
+User-agent: Googlebot
+Disallow: /
+```
+
+Страницы могут быть доступны `Google-CloudVertexBot`, но Agent Search не сможет забрать sitemap через `Googlebot`.
+
+Если для конкретного проекта нужен sitemap-based refresh в Agent Search, нужно разрешить доступ обоим механизмам хотя бы к требуемым URL.
+
+Например:
+
+```robots.txt
+User-agent: Google-CloudVertexBot
+Allow: /
+
+User-agent: Googlebot
+Allow: /sitemap.xml
+```
+
+Но при составлении правил нужно учитывать обычный Google Search: `Googlebot` используется не только Agent Search.
+
+## Google-CloudVertexBot, Googlebot и Google-Extended — это не одно и то же
+
+### Google-CloudVertexBot
+
+Реальный crawler с собственным User-Agent token. Его можно увидеть в HTTP access log и отдельно разрешать или блокировать в `robots.txt`.
+
+### Googlebot
+
+Основной crawler Google. Он используется Google Search и в Agent Search может отдельно забирать sitemap.
+
+### Google-Extended
+
+`Google-Extended` — product token для управления использованием контента некоторыми Gemini/Vertex AI сценариями. У него **нет отдельной строки HTTP User-Agent**.
+
+Поэтому такое правило имеет смысл:
+
+```robots.txt
+User-agent: Google-Extended
+Disallow: /
+```
+
+А попытка заблокировать HTTP-запросы поиском строки `Google-Extended` в заголовке User-Agent обычно не делает того, что ожидается: отдельного crawler User-Agent с этой строкой Google не заявляет.
+
+## Пример раздельной политики
+
+Допустим, сайт хочет:
+
+- оставаться доступным Google Search;
+- не отдавать данные через Google-Extended;
+- разрешить Agent Search только для `/docs/`.
+
+```robots.txt
+User-agent: Googlebot
+Allow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Google-CloudVertexBot
+Allow: /docs/
+Disallow: /
+```
+
+Это три разных решения, и их не следует объединять в один переключатель «разрешить/запретить Google AI».
+
+## CDN и WAF
+
+`robots.txt` — рекомендация crawler'у, а не firewall. Если нужен технический запрет на уровне сервера, CDN или WAF, можно фильтровать реальный `Google-CloudVertexBot` по HTTP User-Agent.
+
+Но User-Agent легко подделать. Если важно убедиться, что запрос действительно пришел от инфраструктуры Google, используйте официальную процедуру верификации crawler/fetcher, а не только строковое сравнение.
+
+Не стоит строить allowlist вида:
+
+```text
+UA содержит Google-CloudVertexBot → доверять всему запросу
+```
+
+Для чувствительных endpoint'ов User-Agent никогда не является аутентификацией.
+
+## Nginx: наблюдение, а не слепая блокировка
+
+Для начала удобнее вынести crawler в отдельную метрику или лог.
+
+```nginx
+map $http_user_agent $is_vertex_bot {
+    default 0;
+    ~*Google-CloudVertexBot 1;
+}
+```
+
+Дальше `$is_vertex_bot` можно использовать в расширенном формате логов или observability pipeline.
+
+Если принято осознанное решение блокировать запросы на уровне Nginx:
+
+```nginx
+if ($http_user_agent ~* "Google-CloudVertexBot") {
+    return 403;
+}
+```
+
+Для обычного управления crawler предпочтительнее корректный `robots.txt`: жесткий `403` нужен только когда это действительно соответствует политике сайта.
+
+## Apache
+
+```apacheconf
+SetEnvIfNoCase User-Agent "Google-CloudVertexBot" vertex_bot
+
+<RequireAll>
+    Require all granted
+    Require not env vertex_bot
+</RequireAll>
+```
+
+Как и в Nginx, это уже серверная блокировка, а не robots-policy.
+
+## Как найти crawler в логах
+
+Nginx/Apache access log:
+
+```bash
+grep -i 'Google-CloudVertexBot' /var/log/nginx/access.log
+```
+
+С частотой запросов по дню:
+
+```bash
+grep -i 'Google-CloudVertexBot' /var/log/nginx/access.log \
+  | awk '{print $4}' \
+  | cut -d: -f1 \
+  | sort | uniq -c
+```
+
+Для реального анализа полезнее сохранять:
+
+- timestamp;
+- URL;
+- status code;
+- bytes sent;
+- request time;
+- User-Agent;
+- IP/ASN после корректной нормализации;
+- cache status.
+
+## Что проверить перед включением Agent Search
+
+1. Какие URL действительно должны попасть в индекс Agent Search.
+2. Нет ли бесконечных URL с query-параметрами.
+3. Доступен ли `robots.txt`.
+4. Разрешен ли `Google-CloudVertexBot` нужным страницам.
+5. Если используется sitemap — может ли `Googlebot` забрать сам sitemap.
+6. Нет ли запрета на CDN/WAF, который конфликтует с `robots.txt`.
+7. Не попадают ли в публичный сайт приватные документы или административные страницы.
+8. Нужна ли доменная верификация для выбранного режима Advanced website indexing.
+
+## Динамические URL
+
+Google Cloud отдельно предупреждает, что автоматическое обнаружение URL на сайтах с большим числом динамических вариантов может раздувать индекс и стоимость хранения.
+
+Для сайта вида:
+
+```text
+/catalog?page=1&sort=name
+/catalog?page=1&sort=price
+/catalog?page=1&utm_source=x
+```
+
+нужно заранее продумать include/exclude patterns, sitemap и канонические URL, а не просто разрешить crawler'у весь домен.
+
+## Что это значит для SEO
+
+Практически ничего напрямую.
+
+Google прямо указывает, что настройки `Google-CloudVertexBot` влияют на обход, инициированный владельцем сайта для Vertex AI Agents, и не влияют на Google Search или другие продукты.
+
+То есть блокировка:
+
+```robots.txt
+User-agent: Google-CloudVertexBot
+Disallow: /
+```
+
+не является способом удалить страницу из Google Search.
+
+И обратное тоже верно: разрешение этого crawler'а не дает преимущества в обычной поисковой выдаче.
+
+## Источники
+
+- [Google Search documentation updates — Introducing Google-CloudVertexBot](https://developers.google.com/search/updates)
+- [Google common crawlers — Google-CloudVertexBot](https://developers.google.com/crawling/docs/crawlers-fetchers/google-common-crawlers)
+- [Google Cloud Agent Search — Prepare data](https://docs.cloud.google.com/generative-ai-app-builder/docs/prepare-data)
+- [Google Cloud Agent Search — Index and refresh with sitemaps](https://docs.cloud.google.com/generative-ai-app-builder/docs/index-refresh-sitemap)
+- [Overview of Google crawlers and fetchers](https://developers.google.com/crawling/docs/crawlers-fetchers/overview-google-crawlers)


### PR DESCRIPTION
## Что добавлено

### Google-CloudVertexBot

Новый материал `docs/info/google/google-cloudvertexbot.md`:

- описывает crawler, официально добавленный Google 20 августа 2026 года;
- объясняет, что он используется для Vertex AI / Agent Search по запросу владельца и не влияет на Google Search;
- содержит примеры `robots.txt` для полного и выборочного доступа;
- разбирает неочевидную связку: страницы обходит `Google-CloudVertexBot`, а sitemap для Agent Search забирает обычный `Googlebot`;
- сравнивает `Google-CloudVertexBot`, `Googlebot` и `Google-Extended`;
- добавляет примеры Nginx/Apache, анализ access log и checklist для Agent Search;
- отдельно предупреждает о динамических URL и возможном раздувании индекса/стоимости.

### Исправление инструкции по AI-ботам

Обновлен `docs/hosting/scripts/block_chatgpt_claude_gemini.md`:

- `Google-Extended` больше не описывается как самостоятельный HTTP User-Agent;
- убрана нерабочая идея ловить `Google-Extended` через `.htaccess` по User-Agent;
- добавлен реальный `Google-CloudVertexBot`;
- добавлены современные примеры Apache/Nginx;
- разведены `robots.txt` policy и жесткая HTTP/WAF-блокировка;
- добавлено предупреждение, что User-Agent не является аутентификацией.

### User-Agent diagnostics

Обновлен `docs/hosting/scripts/user_agents.md`:

- объяснено, почему известная строка User-Agent сама по себе не доказывает принадлежность crawler'у;
- новый Google crawler не должен автоматически попадать в blacklist;
- добавлены команды анализа access log;
- добавлены ссылки на связанные материалы.

## Почему сейчас

20 августа 2026 года Google официально добавил `Google-CloudVertexBot` в документацию crawler'ов. Google Cloud также документирует отдельное использование `Googlebot` для sitemap в Agent Search.

## Verification

- [x] Ветка создана от актуального `main`.
- [x] Ветка на 3 коммита впереди и на 0 позади `main` на момент проверки.
- [x] Diff ограничен 3 Markdown-файлами.
- [x] Различие `Google-CloudVertexBot` / `Googlebot` / `Google-Extended` сверено с официальной документацией Google.
- [x] Не утверждается влияние VertexBot на обычное ранжирование Google Search.

## Источники

- Google Search documentation updates, 20 августа 2026.
- Google common crawlers.
- Google Cloud Agent Search: Prepare data.
- Google Cloud Agent Search: sitemap-based indexing and refresh.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ichinya/seo_recipes/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->