### PR TITLE
Исправить YAML frontmatter новых SEO-материалов

### DIFF
--- a/docs/info/ai/agentic-web.md
+++ b/docs/info/ai/agentic-web.md
@@ -1,6 +1,6 @@
 ---
 title: Agentic web — WebMCP, AEO и готовность сайта к AI-агентам
-description: Как сайты меняются для AI-агентов: WebMCP, Agent Readiness, Answer Engine Optimization, безопасность и практический план внедрения
+description: "Как сайты меняются для AI-агентов: WebMCP, Agent Readiness, Answer Engine Optimization, безопасность и практический план внедрения"
 icon: fa-solid fa-robot
 category: Нейросети
 tag: [AI, агенты, WebMCP, MCP, AEO, Agent Readiness, Cloudflare, SEO]

--- a/docs/info/google/core-update-recovery.md
+++ b/docs/info/google/core-update-recovery.md
@@ -1,6 +1,6 @@
 ---
 title: Что делать после Google Core Update
-description: Практический алгоритм диагностики падения трафика после core update: Search Console, масштаб падения, технические ошибки, качество контента и сроки переоценки
+description: "Практический алгоритм диагностики падения трафика после core update: Search Console, масштаб падения, технические ошибки, качество контента и сроки переоценки"
 icon: fa-brands fa-google
 category: Google
 tag: [Google, Core Update, SEO, Search Console, трафик, диагностика]


### PR DESCRIPTION
## Что исправлено

Исправлены два YAML-frontmatter, из-за которых VuePress/Vercel Preview падал ещё на этапе `gray-matter` / `js-yaml` parsing.

### `docs/info/ai/agentic-web.md`

Двоеточие внутри `description` было оставлено в plain scalar:

```yaml
description: Как сайты меняются для AI-агентов: WebMCP, ...
```

Теперь значение заключено в кавычки.

### `docs/info/google/core-update-recovery.md`

После первого исправления Vercel дошёл до следующего файла с тем же паттерном:

```yaml
description: Практический алгоритм ... core update: Search Console, ...
```

Это значение также заключено в кавычки.

## Почему отдельный PR

Обе ошибки уже находятся в `main` после merge недавних контентных PR и поэтому ломают preview-сборки всех новых веток, а не только PR #138.

Те же fixes временно добавлены в ветку #138, чтобы её preview мог пересобраться до merge этого PR. После попадания исправлений в `main` эти дополнительные изменения исчезнут из content diff #138.

## Verification

- первая ошибка подтверждена build log Vercel: `agentic-web.md`, `YAMLException: incomplete explicit mapping pair`;
- после её исправления Vercel дошёл до второй ошибки: `core-update-recovery.md` с тем же типом YAMLException;
- изменения ограничены кавычками вокруг двух `description`;
- никаких содержательных изменений статей нет.