### PR TITLE
Документировать WebMCP, Chrome DevTools MCP и Developer Knowledge

### DIFF
--- a/docs/hosting/testing/chrome-devtools-mcp.md
+++ b/docs/hosting/testing/chrome-devtools-mcp.md
@@ -1,0 +1,264 @@
+---
+title: Chrome DevTools MCP — runtime-проверка сайта AI-агентом
+description: "Как подключить Chrome DevTools MCP, обойти страницы или Storybook stories, найти console/network ошибки, исправить код и повторно проверить результат"
+icon: fa-brands fa-chrome
+category: Хостинг
+tag: [Тестирование, Chrome, DevTools, MCP, AI, Storybook, VuePress, Runtime]
+---
+
+# Chrome DevTools MCP — runtime-проверка сайта AI-агентом
+
+Успешный build ещё не означает, что сайт нормально работает в браузере. Ошибка может появиться только после hydration, загрузки данных, открытия конкретного route, запуска компонента или ответа внешнего API.
+
+Chrome DevTools MCP подключает coding agent к реальному Chrome. Агент может открывать страницы, читать console, анализировать Network, выполнять действия и после исправления кода повторно проверять результат.
+
+## Практический кейс CyberAgent
+
+В опубликованном Chrome кейсе AI-агент примерно за час прошёл 32 компонента и 236 Storybook stories дизайн-системы Spindle. Он нашёл и исправил один runtime error и два warning, затем подтвердил, что остальные stories работают без этих проблем.
+
+Ценность такого прогона не только в найденных ошибках. Агент механически проверяет большой список состояний, который человеку трудно пройти без пропусков.
+
+## Что проверяет рецепт
+
+- загрузку документа и основных UI-состояний;
+- `console.error`, warnings и unhandled rejections;
+- HTTP 4xx/5xx, CORS, mixed content и заблокированные запросы;
+- переходы между routes;
+- отдельные Storybook stories;
+- результат после автоматического или ручного исправления;
+- отсутствие новых ошибок после повторного прогона.
+
+Это второй слой после build/unit/e2e tests, а не их замена.
+
+## Требования
+
+- актуальная LTS-версия Node.js и npm;
+- текущая stable-версия Chrome;
+- MCP-совместимый агент: Codex, Claude Code, Gemini CLI, Cursor, Copilot или другой клиент;
+- локальный либо staging URL приложения.
+
+## Установка
+
+### Codex
+
+```bash
+codex mcp add chrome-devtools -- npx chrome-devtools-mcp@latest
+```
+
+### Gemini CLI
+
+Расширение с MCP и skills:
+
+```bash
+gemini extensions install --auto-update https://github.com/ChromeDevTools/chrome-devtools-mcp
+```
+
+Только MCP server:
+
+```bash
+gemini mcp add chrome-devtools npx chrome-devtools-mcp@latest
+```
+
+### Claude Code
+
+В Claude Code добавить marketplace и установить plugin:
+
+```text
+/plugin marketplace add ChromeDevTools/chrome-devtools-mcp
+/plugin install chrome-devtools-mcp@chrome-devtools-plugins
+```
+
+### Универсальная JSON-конфигурация
+
+Для клиентов с ключом `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+Для повторяемого CI или командного процесса лучше закрепить проверенную версию package вместо `@latest`.
+
+## Безопасный режим работы
+
+Chrome DevTools MCP получает доступ к содержимому браузера и может действовать от имени активной web-сессии.
+
+Перед прогоном:
+
+1. используйте отдельный browser profile или чистую сессию;
+2. не открывайте в ней почту, платежи, production admin и другие чувствительные вкладки;
+3. начинайте с localhost или staging;
+4. явно ограничьте scope в prompt;
+5. для аудита без изменений напишите «не редактируй файлы и не выполняй write-actions»;
+6. не передавайте production cookies агенту без отдельной необходимости и контроля.
+
+Фраза в prompt — организационное ограничение, а не криптографический sandbox. Полномочия браузера и агента всё равно должны быть минимальными.
+
+## Базовый workflow
+
+### 1. Запустить приложение
+
+Для SEO Recipes:
+
+```bash
+npm run docs:dev
+```
+
+Для Storybook обычно используется команда проекта, например:
+
+```bash
+npm run storybook
+```
+
+Сначала убедитесь, что URL открывается обычным браузером.
+
+### 2. Определить полный список targets
+
+Источник списка должен быть воспроизводимым:
+
+- routes приложения;
+- sitemap;
+- ссылки из навигации;
+- список Storybook stories;
+- заранее подготовленный файл URL;
+- изменённые страницы из PR.
+
+Без списка агент может проверить только несколько заметных экранов и ошибочно назвать аудит полным.
+
+### 3. Проверить каждую страницу
+
+Для каждого target агент должен:
+
+1. открыть URL;
+2. дождаться стабильного состояния;
+3. проверить, что основной контент отрисован;
+4. собрать новые console errors и warnings;
+5. проверить failed/blocked network requests;
+6. выполнить минимальные действия сценария;
+7. записать точный URL, шаги и сообщение ошибки.
+
+### 4. Исправить и повторить
+
+После изменения кода нужно заново открыть затронутую страницу и затем повторить весь smoke-набор. Иначе исправление одной story может сломать общий компонент в других состояниях.
+
+### 5. Сохранить отчёт
+
+Минимальная таблица:
+
+| URL / story | Результат | Console | Network | Действие |
+| --- | --- | --- | --- | --- |
+| `/hosting/providers/` | OK | чисто | чисто | — |
+| `/info/ai/example` | Ошибка | `TypeError...` | `GET /api/... 500` | исправлен handler |
+
+Отдельно перечислите targets, которые не удалось проверить, и причину.
+
+## Prompt для Storybook
+
+```text
+Storybook уже запущен локально.
+
+Используй Chrome DevTools MCP и выполни полный runtime-аудит.
+
+1. Найди все components и stories. Не ограничивайся открытыми или первыми в списке.
+2. Открой каждую story и дождись её загрузки.
+3. Проверь console errors, warnings, unhandled rejections и failed network requests.
+4. Выполни очевидные безопасные интеракции: открыть dropdown/modal, переключить state, заполнить локальную форму без отправки наружу.
+5. Для каждой проблемы запиши component, story, точный текст ошибки и шаги воспроизведения.
+6. Исправь ошибки в коде.
+7. Повторно проверь исправленные stories и затем весь набор.
+8. В конце выдай таблицу: checked, clean, fixed, remaining, skipped.
+
+Не изменяй публичные API компонентов без необходимости и не скрывай warning через отключение логирования.
+```
+
+Для режима только аудита замените пункты 6–7 на запрет редактирования и запрос рекомендаций.
+
+## Prompt для SEO Recipes / VuePress
+
+```text
+Сайт VuePress запущен локально.
+
+Используй Chrome DevTools MCP для runtime-проверки.
+
+1. Собери внутренние ссылки из разделов /info/, /cookbook/ и /hosting/.
+2. Открой каждую опубликованную страницу, а не только index-файлы.
+3. Проверь загрузку основного контента, sidebar, внутренних ссылок и code blocks.
+4. Для каждой страницы проверь console errors/warnings и Network 4xx/5xx/blocked requests.
+5. Отдельно найди broken navigation, hydration errors и ошибки client-side scripts.
+6. Не отправляй формы и не выполняй внешние write-actions.
+7. Исправь ошибки проекта, затем повторно проверь затронутые страницы.
+8. Выдай отчёт с точными URL и итоговым количеством проверенных страниц.
+```
+
+Такой прогон дополняет `npm run docs:build`: build ловит frontmatter и compile-time проблемы, а DevTools MCP проверяет уже работающий сайт в браузере.
+
+## Audit-only prompt для production
+
+```text
+Проведи только read-only аудит указанного production URL через Chrome DevTools MCP.
+
+Разрешено: открыть страницы, читать DOM, console и Network, выполнять безопасную навигацию.
+Запрещено: редактировать файлы, отправлять формы, менять настройки, авторизовываться, создавать или удалять данные.
+
+При любой неоднозначности останови действие и добавь его в список skipped.
+```
+
+Даже при таком prompt лучше использовать неавторизованную или тестовую сессию.
+
+## Что смотреть в Console
+
+- runtime exceptions;
+- hydration mismatch;
+- unhandled promise rejection;
+- Vue/React warnings;
+- deprecated API;
+- CSP и mixed-content violations;
+- ошибки сторонних widgets;
+- повторяющийся warning, который маскирует реальные проблемы.
+
+Не следует «исправлять» аудит простым отключением `console.warn` или фильтрацией сообщений.
+
+## Что смотреть в Network
+
+- HTTP 4xx/5xx;
+- CORS и preflight failures;
+- запросы, зависшие без ответа;
+- redirect loops;
+- неработающие assets/chunks;
+- неверный content type;
+- запросы к localhost из production;
+- утечки секретов в URL/query string;
+- внешние зависимости, блокирующие основной UI.
+
+## Ограничения
+
+- агентный прогон может быть недетерминированным;
+- визуально похожее состояние не гарантирует правильную бизнес-логику;
+- не все auth/payment flows безопасно автоматизировать;
+- один Chrome не заменяет cross-browser tests;
+- длинный список страниц требует явного учёта coverage;
+- внешние API могут давать временные ошибки;
+- performance trace нужно анализировать отдельно от обычного console-аудита.
+
+## Как встроить в release process
+
+1. Build и unit tests.
+2. Обычные deterministic e2e tests.
+3. Chrome DevTools MCP smoke-аудит изменённых routes/stories.
+4. Периодический полный обход всего каталога.
+5. Сохранение отчёта как PR artifact или комментария.
+6. Ручная проверка high-risk сценариев.
+
+Для CI закрепляйте версии Chrome/package, используйте тестовые аккаунты и не позволяйте агенту автоматически публиковать изменения без review.
+
+## Источники
+
+- [Chrome — Get started with Chrome DevTools for agents](https://developer.chrome.com/docs/devtools/agents/get-started)
+- [Chrome — CyberAgent automated runtime error fixing](https://developer.chrome.com/blog/autofix-runtime-devtools-mcp)
+- [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)

--- a/docs/info/ai/README.md
+++ b/docs/info/ai/README.md
@@ -8,6 +8,8 @@ index: false
 
 - [Agentic web: WebMCP, AEO и готовность сайта к AI-агентам](./agentic-web.md)
 
+- [Google Developer Knowledge API и MCP: первоисточники для AI-агентов](./google-developer-knowledge.md)
+
 - [Интеграция нейросетей в SEO: практический гайд по автоматизации продвижения в 2025 году](./neuro-seo-automation.md)
 
 - [Пессимизация нейросетевого контента: как поисковики реагируют на AI‑тексты](./ai-content-pessimization.md)

--- a/docs/info/ai/agentic-web.md
+++ b/docs/info/ai/agentic-web.md
@@ -1,16 +1,16 @@
 ---
 title: Agentic web — WebMCP, AEO и готовность сайта к AI-агентам
-description: "Как сайты меняются для AI-агентов: WebMCP, Agent Readiness, Answer Engine Optimization, безопасность и практический план внедрения"
+description: "Как сайты меняются для AI-агентов: WebMCP, обнаружение и выполнение tools, cross-origin iframe, безопасность, Agent Readiness и AEO"
 icon: fa-solid fa-robot
 category: Нейросети
-tag: [AI, агенты, WebMCP, MCP, AEO, Agent Readiness, Cloudflare, SEO]
+tag: [AI, агенты, WebMCP, MCP, AEO, Agent Readiness, Cloudflare, Chrome, SEO]
 ---
 
 # Agentic web — WebMCP, AEO и готовность сайта к AI-агентам
 
-Поиск и обычный браузинг предполагают, что пользователь сначала видит страницу, затем сам читает, кликает и заполняет формы. AI-агент может работать иначе: найти ресурс, понять доступные действия и выполнить задачу от имени пользователя.
+Поиск и обычный браузинг предполагают, что пользователь видит страницу, читает текст, нажимает кнопки и заполняет формы. AI-агент может работать иначе: найти ресурс, обнаружить доступные действия и вызвать их как структурированные инструменты.
 
-Для владельца сайта появляется новый уровень оптимизации:
+Для владельца сайта появляется несколько дополняющих друг друга уровней:
 
 ```text
 SEO
@@ -19,7 +19,7 @@ SEO
 
 AEO / generative discovery
   ↓
-контент может быть использован в ответе или рекомендации
+контент может попасть в ответ или рекомендацию
 
 agent readiness
   ↓
@@ -30,228 +30,303 @@ WebMCP / tools
 агент может выполнить действие через структурированный инструмент
 ```
 
-Эти уровни дополняют друг друга, а не заменяют обычное SEO.
-
-## Почему тема стала практической в 2026 году
-
-В августе 2026 года Cloudflare собрал несколько направлений в одну agentic-web модель:
-
-- Agent Readiness — техническая оценка того, насколько сайт понятен агентам;
-- Answer Engine Optimization (AEO) — наблюдение за тем, рекомендуют ли AI-ассистенты сайт;
-- WebMCP — экспериментальный browser API, через который страница может явно предоставить агенту инструменты;
-- agent-first browser инфраструктура и MCP-интеграции.
-
-Параллельно WebMCP опубликован как Draft Community Group Report Web Machine Learning Community Group. Это ранняя стадия: API и реализация еще меняются, поэтому внедрение нужно делать через feature detection и с ожиданием будущих изменений.
+WebMCP не заменяет HTML, API, accessibility или SEO. Пока это экспериментальный progressive enhancement для браузеров и агентов, которые поддерживают API.
 
 ## Что такое WebMCP
 
-WebMCP позволяет web-приложению зарегистрировать JavaScript-tools, которые AI-агент может обнаружить и вызвать в текущей вкладке браузера.
+WebMCP позволяет web-приложению зарегистрировать JavaScript-tools в текущем документе. Совместимый браузерный агент может получить их список, изучить JSON Schema, вызвать подходящий tool и обработать результат.
 
-Вместо:
+Вместо хрупкой цепочки:
 
 ```text
 агент → screenshot/DOM → найти кнопку → кликнуть → угадать форму
 ```
 
-становится возможным:
+становится возможна более явная:
 
 ```text
-агент → список tools → выбрать tool → передать структурированные аргументы → получить результат
+агент → getTools() → выбрать tool → executeTool() → получить результат
 ```
 
-Это особенно интересно для сайтов, где пользователь выполняет конкретные действия:
-
-- поиск;
-- фильтрация каталога;
-- расчет стоимости;
-- создание заявки;
-- изменение настроек;
-- добавление в корзину;
-- бронирование;
-- получение статуса;
-- запуск диагностики.
+Это полезно для поиска, фильтрации, расчётов, получения статуса, бронирования, корзины, заявок и других действий, которые уже существуют в web-интерфейсе.
 
 ## WebMCP и обычный MCP — разные уровни
 
-Обычный Model Context Protocol обычно связывает AI-приложение с отдельным MCP server.
+Обычный Model Context Protocol обычно связывает AI-приложение с отдельным MCP server:
 
 ```text
-AI host
-   ↓
-MCP client
-   ↓
-MCP server
-   ↓
-API / database / service
+AI host → MCP client → MCP server → API / database / service
 ```
 
-WebMCP работает непосредственно внутри web page / browser tab:
+WebMCP работает внутри открытой страницы:
 
 ```text
-browser agent
-   ↓
-document.modelContext
-   ↓
-JavaScript tool страницы
-   ↓
-существующий UI / frontend API
+browser agent → document.modelContext → JavaScript tool страницы → frontend/backend API
 ```
 
-WebMCP не следует воспринимать как полный backend MCP server. Текущий draft ориентирован на browser tools.
+WebMCP не следует считать заменой backend MCP server. Browser tool живёт в контексте страницы, зависит от её lifecycle и использует полномочия текущей web-сессии.
 
 ## Текущее состояние API
 
-На момент августа 2026 года WebMCP остается экспериментальным.
+На август 2026 года WebMCP остаётся экспериментальным и меняется. Актуальная документация Chrome описывает не только `registerTool()`, но и:
 
-В актуальных материалах используется API уровня:
+- `getTools()` для обнаружения доступных инструментов;
+- `executeTool()` для ручного вызова найденного tool;
+- событие `toolchange`;
+- отмену регистрации и выполнения через `AbortSignal`;
+- cross-origin tools в iframe через Permissions Policy и списки разрешённых origins.
 
-```js
-document.modelContext.registerTool(...)
-```
-
-Для lifecycle tool рекомендуется `AbortSignal`.
-
-Минимальная идея:
-
-```js
-if ('modelContext' in document) {
-  const controller = new AbortController()
-
-  document.modelContext.registerTool({
-    name: 'search_articles',
-    description: 'Ищет статьи по ключевым словам',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: { type: 'string' }
-      },
-      required: ['query']
-    },
-    execute: async ({ query }) => {
-      const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`)
-      return response.json()
-    }
-  }, { signal: controller.signal })
-}
-```
-
-Код выше нужно рассматривать как ранний пример: API стандарта еще эволюционирует.
-
-## Feature detection обязателен
-
-WebMCP пока нельзя считать универсально доступным browser API.
-
-Поэтому сайт должен продолжать нормально работать без него:
+Поэтому production-код должен использовать feature detection и оставлять обычный UI полностью рабочим.
 
 ```js
 if (!document.modelContext) {
-  // Обычный UI продолжает работать.
+  // Пользователь и сайт продолжают работать через обычный UI/API.
   return
 }
 ```
 
-WebMCP — дополнительный agent interface, а не причина ломать HTML/forms/API для людей.
+## Регистрация read-only tool
 
-## Cloudflare WebMCP
+Начинать лучше с чтения и расчётов без изменения состояния.
 
-Cloudflare в developer preview предлагает добавлять WebMCP bridge на edge без изменения origin-кода.
+```js
+if ('modelContext' in document) {
+  const lifecycle = new AbortController()
 
-Схема:
+  await document.modelContext.registerTool({
+    name: 'search_articles',
+    description: 'Ищет опубликованные статьи по ключевым словам',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          minLength: 2,
+          maxLength: 200
+        }
+      },
+      required: ['query'],
+      additionalProperties: false
+    },
+    annotations: {
+      readOnlyHint: true,
+      untrustedContentHint: true
+    },
+    execute: async ({ query }, { signal }) => {
+      const response = await fetch(
+        `/api/search?q=${encodeURIComponent(query)}`,
+        { signal }
+      )
 
-```text
-origin HTML
-   ↓
-Cloudflare edge / HTMLRewriter
-   ↓
-добавляется bridge script
-   ↓
-браузерный агент видит WebMCP tools
+      if (!response.ok) {
+        throw new Error(`Search failed: HTTP ${response.status}`)
+      }
+
+      return JSON.stringify(await response.json())
+    }
+  }, { signal: lifecycle.signal })
+
+  // При размонтировании компонента или смене страницы tool можно снять:
+  // lifecycle.abort()
+}
 ```
 
-В опубликованном примере Cloudflare добавляет script с `/.webmcp/bridge.js` и tool packs.
+JSON Schema помогает агенту сформировать аргументы, но не заменяет server-side validation, rate limit и проверку прав.
 
-Это удобно для эксперимента, но важно учитывать:
+## Lifecycle и отмена выполнения
 
-- функция preview, а не стабильный production contract;
-- Cloudflare становится частью agent-interface;
-- tools нужно проверять так же тщательно, как API;
-- нельзя предполагать, что автоматически сгенерированный tool безопасен только потому, что его добавил edge layer.
+У WebMCP два разных `AbortSignal`:
 
-## Agent Readiness
+1. `signal` в options `registerTool()` управляет временем жизни зарегистрированного tool;
+2. `signal`, переданный вторым аргументом в `execute`, сообщает, что пользователь или агент отменил конкретное выполнение.
 
-Agent Readiness отвечает на технический вопрос:
+Долгий `fetch`, stream или вычисление нужно связывать с signal выполнения, иначе отменённая операция продолжит расходовать ресурсы.
 
-> Может ли агент нормально прочитать и использовать сайт?
-
-Это ближе к техническому аудиту, чем к ранжированию.
-
-Типичные проблемы:
-
-- критическая информация появляется только после сложной цепочки JS;
-- кнопки имеют неясные названия;
-- форма не имеет нормальных labels;
-- контент разбит на декоративные элементы без семантики;
-- важный endpoint невозможно вызвать без имитации множества кликов;
-- сайт агрессивно блокирует весь машинный трафик;
-- robots/WAF правила противоречат реальной бизнес-задаче;
-- каталог имеет бесконечные URL variants;
-- нет стабильных идентификаторов сущностей.
-
-Многие исправления полезны одновременно людям, accessibility tools, поисковым системам и агентам.
-
-## AEO — Answer Engine Optimization
-
-Cloudflare использует термин AEO для оценки того, как AI assistants цитируют и рекомендуют сайт.
-
-Их инструмент отправляет тематические запросы моделям и измеряет показатели вроде citation/recommendation rate.
-
-К этому нужно относиться как к отдельному аналитическому сигналу, а не как к официальному фактору Google Search.
-
-### Не смешивать AEO и Google SEO
-
-Google отдельно пишет, что для AI features Search продолжают действовать обычные SEO best practices и не требуется специальная «AI-разметка».
-
-Поэтому утверждение:
-
-```text
-AEO заменяет SEO
+```js
+execute: async ({ url }, { signal }) => {
+  const response = await fetch(url, { signal })
+  return response.text()
+}
 ```
 
-слишком сильное.
+Начиная с Chrome 153, снятие регистрации tool не должно отменять и ломать уже запущенные executions. Это полезно для React/Vue/Angular-компонентов, которые могут размонтироваться во время выполнения. Но сам handler всё равно должен корректно обрабатывать отмену конкретного вызова.
 
-Более корректно:
+## Обнаружение tools через getTools()
 
-```text
-SEO → discoverability в поиске
-AEO → discoverability/recommendation в answer engines
-Agent readiness → способность агента использовать сайт
-WebMCP → явный интерфейс действий для browser agent
+`getTools()` возвращает доступные вызывающему документу tools в алфавитном порядке.
+
+```js
+const tools = await document.modelContext.getTools()
+const searchTool = tools.find(tool => tool.name === 'search_articles')
+
+if (!searchTool) {
+  throw new Error('search_articles is unavailable')
+}
 ```
 
-## Практическая матрица технологий
+Обнаружение нужно выполнять динамически. Нельзя предполагать, что tool навсегда существует: его может зарегистрировать или снять компонент, iframe либо feature flag.
 
-| Механизм | Основная задача | Исполняет действия | Влияет на Google Search напрямую |
-| --- | --- | --- | --- |
-| `robots.txt` | управление crawler access | Нет | Может влиять на crawl |
-| Schema.org | описание сущностей/контента | Нет | Используется поддерживаемыми Search features |
-| sitemap | discovery/refresh URL | Нет | Да, как сигнал discovery |
-| `llms.txt` | сторонний convention | Нет | Google Search его не использует |
-| backend MCP | tools/resources/prompts для AI host | Да | Нет |
-| WebMCP | tools текущей browser page | Да | Нет подтвержденного ranking эффекта |
-| Preferred Sources | пользовательский выбор источника Google | Нет | Влияет на опыт конкретного пользователя |
-| Agent Readiness | аудит пригодности сайта для агента | Нет | Не является Google ranking signal |
-| AEO monitoring | наблюдение за рекомендациями моделей | Нет | Не является Google Search Console |
+## Выполнение tool через executeTool()
+
+В актуальном API аргументы передаются валидной JSON-строкой, а не обычным JavaScript-объектом.
+
+```js
+const controller = new AbortController()
+
+const result = await document.modelContext.executeTool(
+  searchTool,
+  JSON.stringify({ query: 'WebMCP' }),
+  { signal: controller.signal }
+)
+
+console.log(result)
+
+// При необходимости:
+// controller.abort()
+```
+
+Метод возвращает результат выполнения или `null`, если tool инициировал навигацию.
+
+## Реакция на toolchange
+
+Список инструментов может меняться после загрузки страницы. Например, пользователь вошёл в аккаунт, открыл карточку товара или iframe закончил инициализацию.
+
+```js
+async function refreshTools() {
+  const tools = await document.modelContext.getTools()
+  console.table(tools.map(({ name, origin }) => ({ name, origin })))
+}
+
+await refreshTools()
+
+document.modelContext.addEventListener('toolchange', refreshTools)
+```
+
+Handler не должен автоматически выполнять новый tool. Событие означает только то, что список нужно перечитать.
+
+## Cross-origin WebMCP в iframe
+
+Cross-origin tools по умолчанию недоступны. Для доступа одновременно нужны три явных шага:
+
+1. родитель делегирует iframe Permissions Policy через `allow="tools"`;
+2. iframe регистрирует tool с `exposedTo` и точным origin родителя;
+3. родитель запрашивает tools с `fromOrigins` и точным origin iframe.
+
+Поддерживаются только secure origins.
+
+### 1. Родительская страница подключает widget
+
+```html
+<iframe
+  src="https://shop-widget.example/product/42"
+  allow="tools"
+  title="Остатки товара"
+></iframe>
+```
+
+### 2. Widget предоставляет read-only tool
+
+Код выполняется внутри `https://shop-widget.example`:
+
+```js
+const lifecycle = new AbortController()
+
+await document.modelContext.registerTool({
+  name: 'get_product_stock',
+  description: 'Возвращает доступный остаток товара по productId',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      productId: { type: 'string', minLength: 1, maxLength: 64 }
+    },
+    required: ['productId'],
+    additionalProperties: false
+  },
+  annotations: {
+    readOnlyHint: true,
+    untrustedContentHint: true
+  },
+  execute: async ({ productId }, { signal }) => {
+    const response = await fetch(
+      `/api/products/${encodeURIComponent(productId)}/stock`,
+      { signal, credentials: 'include' }
+    )
+
+    if (!response.ok) {
+      throw new Error(`Stock API failed: HTTP ${response.status}`)
+    }
+
+    return JSON.stringify(await response.json())
+  }
+}, {
+  signal: lifecycle.signal,
+  exposedTo: ['https://catalog.example']
+})
+```
+
+### 3. Родитель обнаруживает и вызывает tool
+
+Код выполняется на `https://catalog.example`:
+
+```js
+const tools = await document.modelContext.getTools({
+  fromOrigins: ['https://shop-widget.example']
+})
+
+const stockTool = tools.find(tool =>
+  tool.name === 'get_product_stock' &&
+  tool.origin === 'https://shop-widget.example'
+)
+
+if (!stockTool) {
+  throw new Error('Trusted stock tool is unavailable')
+}
+
+const result = await document.modelContext.executeTool(
+  stockTool,
+  JSON.stringify({ productId: '42' })
+```
+
+`allow="tools"` не является разрешением всем внешним сайтам. И `exposedTo`, и `fromOrigins` должны содержать минимальные точные allowlists.
+
+## Threat model для embedded widgets
+
+Cross-origin WebMCP превращает embedded-компонент в программный интерфейс. Перед включением нужно отдельно проверить:
+
+### Идентичность origin
+
+Родитель должен проверять `tool.origin`, а iframe — публиковать tool только доверенным origins. Не выбирайте инструмент только по имени.
+
+### Авторизацию на backend
+
+Наличие tool не даёт новых прав. Backend обязан проверить session, tenant, роль и доступ к конкретной сущности так же, как при обычном HTTP-запросе.
+
+### Недоверенный результат
+
+Ответ iframe может содержать пользовательский контент или данные внешней системы. Его нельзя автоматически превращать в привилегированные инструкции для агента.
+
+### Prompt injection
+
+Текст товара, комментария, тикета или документа может пытаться управлять агентом. Контент нужно считать данными, а не системными инструкциями.
+
+### Read/write separation
+
+`get_product_stock` и `place_order` — разные уровни риска. Платёж, публикация, удаление и изменение аккаунта требуют отдельного подтверждения пользователя, idempotency и audit log.
+
+### Отзыв доступа
+
+При logout, смене tenant, закрытии widget или отключении feature flag нужно снимать регистрацию tool и обновлять доступный список.
 
 ## Какой tool давать агенту
 
-Плохой tool:
+Плохой интерфейс:
 
 ```text
 name: do_stuff
 input: arbitrary string
 ```
 
-Хороший tool:
+Более предсказуемый:
 
 ```text
 name: search_hosting_providers
@@ -261,29 +336,20 @@ input:
   min_ram_gb: number
 ```
 
-Хороший WebMCP tool должен иметь:
+Хороший WebMCP tool имеет:
 
-- узкое назначение;
-- стабильное имя;
+- узкое назначение и стабильное имя;
 - понятное описание;
-- строгую input schema;
+- строгую schema с `additionalProperties: false` там, где это уместно;
 - минимальный набор параметров;
-- предсказуемый structured output;
-- явное разделение read/write действий;
-- ошибки, которые можно обработать программно.
+- структурированный результат;
+- программно различимые ошибки;
+- annotations, соответствующие реальному поведению;
+- отдельные read и write операции.
 
 ## Read-only tools — лучший первый шаг
 
-Начинать стоит с безопасных функций:
-
-- поиск;
-- чтение статуса;
-- фильтрация;
-- получение метаданных;
-- расчет без сохранения;
-- preview.
-
-Например для SEO Recipes:
+Для SEO Recipes безопасными кандидатами будут:
 
 ```text
 search_articles(query)
@@ -293,172 +359,134 @@ find_recipe(topic)
 get_recent_hosting_incidents(provider)
 ```
 
-Это полезнее и безопаснее, чем сразу давать агенту write access.
+Они позволяют сравнить agent flow с обычной навигацией, не предоставляя право менять данные.
 
 ## Опасные write tools
 
-Следующие действия требуют отдельного threat model:
+Отдельного threat model требуют:
 
-- удалить аккаунт;
-- совершить платеж;
-- изменить email;
-- сменить пароль;
-- удалить данные;
-- опубликовать контент;
-- отправить сообщение;
-- сделать заказ;
-- выполнить административную операцию.
+- платежи и заказы;
+- смена email или пароля;
+- удаление аккаунта или данных;
+- публикация контента;
+- отправка сообщений;
+- административные действия.
 
-Нельзя считать, что наличие AI-агента автоматически является согласием пользователя.
-
-Для irreversible действий нужны дополнительные confirmation/authorization механизмы.
+Наличие AI-агента не является согласием пользователя. Для необратимых операций нужны confirmation, повторная проверка параметров, idempotency и серверный audit log.
 
 ## Security checklist
 
-### 1. Не хранить секреты в client-side tool
+1. Не хранить секреты в client-side tool.
+2. Проверять auth и permissions на сервере.
+3. Валидировать аргументы повторно на backend.
+4. Ограничивать origins точными allowlists.
+5. Проверять `tool.origin` перед вызовом cross-origin tool.
+6. Отделять read от write.
+7. Передавать execution `signal` в долгие операции.
+8. Не исполнять инструкции из недоверенного результата.
+9. Логировать write calls без чувствительных данных.
+10. Оставлять обычный UI и accessibility рабочими.
 
-Плохо:
+## Agent Readiness
 
-```js
-const API_KEY = 'secret'
-```
+Agent Readiness отвечает на технический вопрос: может ли агент нормально прочитать и использовать сайт?
 
-WebMCP выполняется в web context. Секреты должны оставаться на backend.
+Типичные проблемы:
 
-### 2. Проверять авторизацию на сервере
+- критическая информация появляется только после сложной цепочки JavaScript;
+- кнопки и формы не имеют понятных labels;
+- контент разбит на декоративные элементы без семантики;
+- важное действие требует имитации множества кликов;
+- robots/WAF правила противоречат бизнес-задаче;
+- каталог создаёт бесконечные URL-варианты;
+- у сущностей нет стабильных идентификаторов.
 
-Если tool вызывает:
+Многие исправления одновременно полезны людям, accessibility tools, поисковым системам и агентам.
+
+## AEO — Answer Engine Optimization
+
+AEO измеряет, как answer engines цитируют и рекомендуют сайт. Это отдельный аналитический слой, а не подтверждённый ranking factor Google Search.
 
 ```text
-POST /api/order
+SEO → discoverability в поиске
+AEO → discoverability/recommendation в answer engines
+Agent Readiness → способность агента понять сайт
+WebMCP → явный интерфейс действий в браузере
 ```
 
-backend обязан проверить session/permissions так же, как для обычного UI.
+Наличие `document.modelContext` само по себе не даёт оснований ожидать рост позиций.
 
-### 3. Не доверять аргументам агента
+## Практическая матрица
 
-Input schema помогает агенту, но не заменяет server-side validation.
+| Механизм | Основная задача | Исполняет действия | Прямой ranking signal Google |
+| --- | --- | --- | --- |
+| `robots.txt` | управление crawler access | Нет | Может влиять на crawl |
+| Schema.org | описание сущностей и контента | Нет | Используется поддерживаемыми Search features |
+| sitemap | discovery и refresh URL | Нет | Сигнал discovery |
+| `llms.txt` | сторонний convention | Нет | Google Search его не использует |
+| backend MCP | tools/resources/prompts для AI host | Да | Нет |
+| WebMCP | tools текущей browser page | Да | Не подтверждён |
+| Agent Readiness | аудит пригодности сайта для агента | Нет | Нет |
+| AEO monitoring | наблюдение за ответами моделей | Нет | Нет |
 
-### 4. Разделять read и write
+## Cloudflare WebMCP
 
-Read-only tool можно дать широкому agent flow. Write tool должен иметь более жесткие guardrails.
+Cloudflare в developer preview предлагает добавлять WebMCP bridge на edge без изменения origin-кода:
 
-### 5. Защищаться от prompt injection через контент
+```text
+origin HTML → Cloudflare edge / HTMLRewriter → bridge script → WebMCP tools
+```
 
-Страница может содержать пользовательский текст, комментарии и внешние данные. Нельзя превращать текст страницы в инструкции с привилегиями.
-
-### 6. Audit log
-
-Для write-action полезно сохранять:
-
-- user/session;
-- tool name;
-- аргументы после редактирования чувствительных данных;
-- результат;
-- timestamp;
-- confirmation state.
+Это удобно для эксперимента, но edge-generated tool нужно проверять так же тщательно, как вручную написанный API. Перед включением проверяют CSP, cache behavior, injected script, auth, набор tools, fallback без WebMCP и быстрый rollback.
 
 ## WebMCP и accessibility
 
-Хорошо спроектированная agent-interface часто заставляет владельца сайта лучше описать:
-
-- сущности;
-- действия;
-- параметры;
-- состояния;
-- ошибки.
-
-Это пересекается с accessibility и API design, но WebMCP не заменяет ARIA, семантический HTML и обычную доступность.
+WebMCP не заменяет semantic HTML, ARIA, labels, keyboard navigation и обычные формы. Пользователь не должен зависеть от наличия AI-агента, чтобы выполнить основную задачу.
 
 ## Эксперимент для SEO Recipes
 
-SEO Recipes — удобный сайт для безопасного read-only эксперимента.
-
 ### Этап 1. Baseline
 
-Проверить, может ли агент без специальных tools:
+Без специальных tools попросить агента:
 
-1. найти карточку конкретного провайдера;
+1. найти карточку провайдера;
 2. определить его категорию;
-3. найти последний подтвержденный инцидент;
-4. найти инструкцию по определенной серверной задаче;
+3. найти последний подтверждённый инцидент;
+4. найти серверную инструкцию;
 5. сравнить два материала.
 
-Зафиксировать:
-
-- число шагов;
-- число ошибок навигации;
-- токены/время;
-- корректность ответа;
-- какие URL пришлось открыть.
+Зафиксировать число шагов, ошибки навигации, время, токены, точность и открытые URL.
 
 ### Этап 2. Read-only tools
 
-Добавить экспериментальные tools:
+Добавить 3–5 инструментов поиска и чтения. Для каждого определить schema, результат, ошибки и логирование.
 
-```text
-search_recipes
-get_provider
-get_provider_incidents
-find_related_articles
-```
+### Этап 3. Повторный тест
 
-### Этап 3. Повторить тест
+Сравнить baseline и WebMCP flow на одинаковых задачах. Польза есть, если агент получает тот же корректный результат стабильнее и с меньшим числом navigation steps.
 
-Сравнить baseline и WebMCP flow.
-
-Если agent получает тот же результат стабильнее и с меньшим количеством navigation steps — interface приносит практическую пользу.
-
-## Что можно реализовать без Cloudflare
-
-Если сайт не использует Cloudflare, можно экспериментировать с WebMCP напрямую в frontend-коде и поддерживаемом experimental browser.
-
-Для production пока разумно считать WebMCP progressive enhancement:
-
-```text
-обычный HTML/UI/API — основной интерфейс
-WebMCP — дополнительный experimental interface
-```
-
-## Что можно тестировать на Cloudflare
-
-Если домен уже проксируется через Cloudflare, developer preview позволяет быстро проверить edge-injected WebMCP без изменения origin.
-
-Перед включением стоит проверить:
-
-- CSP;
-- cache behavior;
-- injected script;
-- какие tools реально экспонируются;
-- authorization;
-- поведение без WebMCP browser support;
-- rollback одним переключателем.
+Для runtime-проверки страницы и console/network ошибок можно использовать отдельный рецепт [Chrome DevTools MCP](../../hosting/testing/chrome-devtools-mcp.md).
 
 ## Метрики agent-ready сайта
 
-Нельзя сводить все к одному score.
-
-Практический набор:
-
 ### Discoverability
 
-- crawl доступность;
-- sitemap;
-- canonical;
+- crawl-доступность;
+- sitemap и canonical;
 - structured data;
-- нормальная внутренняя перелинковка.
+- внутренняя перелинковка.
 
 ### Readability
 
 - semantic HTML;
 - текст доступен без screenshot OCR;
-- понятные сущности и заголовки;
+- понятные заголовки и сущности;
 - стабильные URL.
 
 ### Actionability
 
-- формы и действия имеют понятную семантику;
-- есть API или tools;
+- формы имеют семантику;
+- API/tools узкие и предсказуемые;
 - ошибки структурированы;
 - write actions защищены.
 
@@ -467,50 +495,38 @@ WebMCP — дополнительный experimental interface
 - crawler/agent traffic можно выделить;
 - tool calls логируются;
 - ошибки видны;
-- можно сравнить human и agent flow.
+- human и agent flow можно сравнить.
 
 ## Что не стоит делать
 
-### Не создавать скрытый «SEO-текст для агентов»
-
-Если content отличается для людей и машин с целью манипуляции, возникают те же риски, что у обычного cloaking.
-
-### Не добавлять бессмысленные tools
-
-Tool только ради наличия WebMCP усложняет frontend и поверхность атаки.
-
-### Не давать write access без confirmation
-
-Особенно платежи, удаление и публикация.
-
-### Не строить стратегию только на одном vendor score
-
-Cloudflare Agent Readiness/AEO полезны как наблюдение, но web/AI ecosystem шире одного провайдера.
-
-### Не путать WebMCP с ranking signal
-
-Пока нет оснований писать, что наличие `document.modelContext` повышает позиции Google.
+- создавать скрытый «SEO-текст для агентов»;
+- добавлять tools без полезного сценария;
+- давать write access без подтверждения;
+- доверять cross-origin tool только по имени;
+- считать vendor score универсальной оценкой;
+- путать WebMCP с ranking signal;
+- ломать обычный UI ради экспериментального API.
 
 ## Минимальный план внедрения
 
 1. Выбрать 3–5 read-only сценариев.
 2. Записать baseline agent flow.
 3. Проверить semantic HTML и accessibility.
-4. Определить JSON schemas tools.
-5. Добавить WebMCP только через feature detection.
-6. Не помещать секреты в frontend.
-7. Проверить backend auth/validation.
-8. Запустить тесты с агентным браузером.
-9. Логировать tool calls.
-10. Сравнить качество с baseline.
-11. Оставить обычный UI полностью рабочим.
-12. Перепроверять спецификацию при обновлениях browser API.
+4. Определить JSON Schemas и structured output.
+5. Добавить feature detection.
+6. Связать lifecycle и execution с `AbortSignal`.
+7. Для iframe определить точные `exposedTo` и `fromOrigins`.
+8. Проверить backend auth, validation и rate limit.
+9. Прогнать runtime-тест с агентным браузером.
+10. Логировать tool calls и ошибки.
+11. Сравнить результат с baseline.
+12. Перепроверять API при новых версиях Chrome.
 
 ## Источники
 
+- [Chrome — WebMCP Imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)
+- [Chrome — WebMCP security considerations](https://developer.chrome.com/docs/ai/webmcp/security)
 - [WebMCP Draft Community Group Report](https://webmachinelearning.github.io/webmcp/)
-- [Google Chrome modern web guidance — WebMCP](https://github.com/GoogleChrome/modern-web-guidance-src/blob/main/guides/webmcp/webmcp/guide.md)
 - [Cloudflare — Give any website a WebMCP interface](https://blog.cloudflare.com/webmcp/)
 - [Cloudflare — From ranking to recommended: AEO and Agent Readiness](https://blog.cloudflare.com/aeo/)
-- [Cloudflare Agents Week review](https://blog.cloudflare.com/agents-week-review-august-2026/)
 - [Model Context Protocol specification](https://modelcontextprotocol.io/specification/2026-07-28)

--- a/docs/info/ai/agentic-web.md
+++ b/docs/info/ai/agentic-web.md
@@ -285,6 +285,7 @@ if (!stockTool) {
 const result = await document.modelContext.executeTool(
   stockTool,
   JSON.stringify({ productId: '42' })
+)
 ```
 
 `allow="tools"` не является разрешением всем внешним сайтам. И `exposedTo`, и `fromOrigins` должны содержать минимальные точные allowlists.

--- a/docs/info/ai/google-developer-knowledge.md
+++ b/docs/info/ai/google-developer-knowledge.md
@@ -1,0 +1,288 @@
+---
+title: Google Developer Knowledge API и MCP — первоисточники для AI-агентов
+description: "Как подключить Developer Knowledge MCP или API, искать официальную документацию Google, фильтровать результаты по relevanceScore и проверять ответы по исходным страницам"
+icon: fa-brands fa-google
+category: Нейросети
+tag: [AI, MCP, Google, Developer Knowledge, API, Grounding, Документация]
+---
+
+# Google Developer Knowledge API и MCP — первоисточники для AI-агентов
+
+Обычный web search смешивает официальную документацию, старые статьи, форумы и пересказы. Google Developer Knowledge предоставляет отдельный corpus публичной developer-документации и два способа доступа:
+
+- REST/API для программного поиска и получения Markdown-документов;
+- remote MCP server для coding/research agents.
+
+Это удобно, когда агент должен сначала проверить первоисточник по Google Cloud, Chrome, Firebase, Android, Maps и другим технологиям, а затем писать код или материал.
+
+## Что изменилось в 2026 году
+
+- 16 апреля Developer Knowledge API и MCP server стали GA;
+- 17 июля endpoint `AnswerQuery` стал GA;
+- 18 августа появились команды `gcloud alpha developer-knowledge`;
+- 21 августа поле `relevance_score` появилось в стабильном v1 API.
+
+В REST JSON поле называется `relevanceScore` и имеет диапазон `0.0–1.0`: большее значение означает более высокую релевантность chunk поисковому запросу.
+
+## Что находится в corpus
+
+Corpus включает публичные страницы поддерживаемых developer-доменов, среди которых Google Cloud, Firebase, Android, Chrome, web.dev, Maps и другие источники из официального списка.
+
+Важно понимать ограничения:
+
+- результаты пока только на английском;
+- GitHub, сторонние OSS-сайты, блоги и YouTube не входят в corpus;
+- наличие страницы в интернете не гарантирует её наличие в Developer Knowledge;
+- `updateTime` помогает оценить свежесть записи, но не отменяет проверку исходного URL;
+- это специализированный источник, а не замена всему web search.
+
+## API, MCP и обычный web search
+
+| Способ | Когда использовать | Что возвращает | Контроль |
+| --- | --- | --- | --- |
+| Web search | новости, сторонние кейсы, обсуждения, продукты вне corpus | страницы из разных источников | нужен ручной отбор доверия |
+| `SearchDocumentChunks` / `search_documents` | найти релевантные фрагменты официальной документации | chunks, metadata, `parent`, URL, score | высокий контроль источника |
+| `GetDocument` / `get_documents` | прочитать полную страницу после поиска | полный Markdown и metadata | расходует больше context |
+| `AnswerQuery` / `answer_query` | получить синтезированный grounded answer | ответ с references/citations | нужно проверить ссылки и цитаты |
+
+Для подготовки технической статьи обычно лучше начинать с chunks, затем получать только нужные полные документы.
+
+## Подготовка Google Cloud project
+
+Задайте project и включите API:
+
+```bash
+export PROJECT_ID="your-project-id"
+
+gcloud services enable developerknowledge.googleapis.com \
+  --project="$PROJECT_ID"
+```
+
+После 17 марта 2026 года remote MCP server должен включаться вместе с API. Если для проекта это не произошло, официальный guide предлагает отдельную команду:
+
+```bash
+gcloud beta services mcp enable developerknowledge.googleapis.com \
+  --project="$PROJECT_ID"
+```
+
+Для REST или MCP через API key создайте отдельный key, ограничьте его Developer Knowledge API и не сохраняйте значение в Git.
+
+```bash
+export DEVELOPERKNOWLEDGE_API_KEY="YOUR_API_KEY"
+```
+
+## Поиск chunks через REST
+
+Пример поиска материалов Chrome только в `developer.chrome.com`:
+
+```bash
+curl -G "https://developerknowledge.googleapis.com/v1/documents:searchDocumentChunks" \
+  --data-urlencode "query=Chrome WebMCP executeTool" \
+  --data-urlencode 'filter=data_source = "developer.chrome.com"' \
+  --data-urlencode "pageSize=10" \
+  --data-urlencode "key=$DEVELOPERKNOWLEDGE_API_KEY"
+```
+
+Результат содержит:
+
+- `parent` — resource name полного документа;
+- `id` — идентификатор chunk;
+- `content` — найденный фрагмент;
+- `document.title` и `document.uri`;
+- `document.dataSource` и `document.updateTime`;
+- `relevanceScore` — относительную релевантность запросу.
+
+## Как использовать relevanceScore
+
+Score полезен для сортировки и отсечения слабых совпадений, но не является оценкой истинности или качества всей страницы.
+
+Пример локальной эвристики:
+
+```bash
+curl -sG "https://developerknowledge.googleapis.com/v1/documents:searchDocumentChunks" \
+  --data-urlencode "query=Chrome WebMCP executeTool" \
+  --data-urlencode 'filter=data_source = "developer.chrome.com"' \
+  --data-urlencode "pageSize=20" \
+  --data-urlencode "key=$DEVELOPERKNOWLEDGE_API_KEY" \
+| jq '.results[]
+    | select(.relevanceScore >= 0.75)
+    | {
+        score: .relevanceScore,
+        title: .document.title,
+        uri: .document.uri,
+        updated: .document.updateTime,
+        parent
+      }'
+```
+
+Порог `0.75` — пример для конкретного pipeline, а не правило Google. Его нужно подбирать по своим запросам и не использовать как единственное условие.
+
+## Фильтры
+
+`SearchDocumentChunks` поддерживает строгие фильтры по metadata родительского документа:
+
+- `data_source`;
+- `update_time`;
+- `uri`;
+- `content_length_bytes`.
+
+Пример нескольких официальных web-источников и ограничения по дате:
+
+```bash
+curl -G "https://developerknowledge.googleapis.com/v1/documents:searchDocumentChunks" \
+  --data-urlencode "query=service worker" \
+  --data-urlencode 'filter=(data_source = "developer.chrome.com" OR data_source = "web.dev") AND update_time >= "2026-01-01T00:00:00Z"' \
+  --data-urlencode "key=$DEVELOPERKNOWLEDGE_API_KEY"
+```
+
+Фильтр ограничивает corpus, а текстовый `query` определяет релевантность внутри него.
+
+## Получение полного документа
+
+Возьмите `parent` из результата, например:
+
+```text
+documents/developer.chrome.com/docs/ai/webmcp/imperative-api
+```
+
+И передайте его в path:
+
+```bash
+PARENT="documents/developer.chrome.com/docs/ai/webmcp/imperative-api"
+
+curl "https://developerknowledge.googleapis.com/v1/${PARENT}?key=$DEVELOPERKNOWLEDGE_API_KEY"
+```
+
+Полный `content` приходит в Markdown. Для экономии bandwidth/context можно запросить только metadata:
+
+```bash
+curl "https://developerknowledge.googleapis.com/v1/${PARENT}?view=DOCUMENT_VIEW_BASIC&key=$DEVELOPERKNOWLEDGE_API_KEY"
+```
+
+Batch endpoint получает до 20 документов, но не следует без необходимости загружать в LLM все найденные страницы.
+
+## Подключение remote MCP
+
+Endpoint:
+
+```text
+https://developerknowledge.googleapis.com/mcp
+```
+
+### Claude Code
+
+```bash
+claude mcp add google-dev-knowledge \
+  --transport http \
+  https://developerknowledge.googleapis.com/mcp \
+  --header "X-Goog-Api-Key: YOUR_API_KEY"
+```
+
+### Cursor
+
+`.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "google-developer-knowledge": {
+      "url": "https://developerknowledge.googleapis.com/mcp",
+      "headers": {
+        "X-Goog-Api-Key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Не коммитьте реальный key. Способ подстановки environment variable зависит от конкретного MCP client.
+
+## MCP tools
+
+Remote server предоставляет:
+
+- `search_documents` — ищет chunks и возвращает `parent`;
+- `get_documents` — получает полное содержимое нескольких документов;
+- `answer_query` — формирует grounded answer; в MCP reference инструмент пока отмечен как Preview.
+
+`AnswerQuery` API endpoint уже GA, но статус конкретного MCP tool нужно проверять отдельно.
+
+Проверочный prompt:
+
+```text
+Найди в Google Developer Knowledge официальную документацию о Chrome WebMCP executeTool.
+Сначала используй search_documents, покажи title, URL, update time и relevance score.
+Полный документ получи только для двух самых релевантных результатов.
+Не используй сторонние источники до завершения этого шага.
+```
+
+## gcloud alpha
+
+С 18 августа 2026 года доступны команды:
+
+```bash
+gcloud alpha developer-knowledge answer-query --help
+gcloud alpha developer-knowledge documents describe --help
+gcloud alpha developer-knowledge documents search-chunks --help
+```
+
+Команды относятся к alpha-компоненту и могут менять flags. Перед автоматизацией стоит проверять встроенный `--help` установленной версии gcloud и закреплять ожидаемый формат вывода.
+
+## Pipeline для SEO Recipes
+
+Практическая последовательность:
+
+```text
+технический вопрос
+  ↓
+search_documents / SearchDocumentChunks
+  ↓
+убрать слабые и нерелевантные chunks
+  ↓
+проверить title, URL, dataSource, updateTime
+  ↓
+get_documents только для нужных страниц
+  ↓
+составить черновик со ссылками на первоисточники
+  ↓
+дополнить web search новостями и сторонними кейсами
+  ↓
+финально перепроверить утверждения по исходным страницам
+```
+
+Для материалов про Chrome, Google Cloud или Firebase это снижает риск сослаться на старый пересказ вместо текущей документации.
+
+## Пример policy для research agent
+
+```text
+При вопросах о технологиях Google:
+
+1. Сначала используй Google Developer Knowledge.
+2. Предпочитай SearchDocumentChunks/search_documents прямому answer_query, если нужны точные формулировки.
+3. Не загружай полные документы без необходимости.
+4. Отбрасывай результаты с неподходящим dataSource даже при высоком score.
+5. Указывай исходный URL и updateTime.
+6. Считай relevanceScore сигналом ранжирования, а не доказательством корректности.
+7. После официального corpus используй web search для новостей, GitHub issues и сторонних кейсов.
+```
+
+## Ограничения и безопасность
+
+- ограничивайте API key конкретным API;
+- не храните key в репозитории или prompt history;
+- учитывайте quotas и HTTP 429;
+- запрашивайте конкретные темы, иначе полные документы быстро заполняют context window;
+- результаты только на английском;
+- corpus не содержит все источники;
+- `updateTime` относится к записи документа и не гарантирует, что каждая деталь страницы новая;
+- generated answer всё равно проверяется по references;
+- для сторонних библиотек нужен отдельный поиск в официальном repo/docs.
+
+## Источники
+
+- [Developer Knowledge release notes](https://developers.google.com/knowledge/release-notes)
+- [Connect to the Developer Knowledge MCP server](https://developers.google.com/knowledge/mcp)
+- [Search and retrieve documents](https://developers.google.com/knowledge/howto)
+- [Developer Knowledge corpus reference](https://developers.google.com/knowledge/corpus)
+- [MCP tools reference](https://developers.google.com/knowledge/reference/mcp)
+- [Developer Knowledge REST API](https://developers.google.com/knowledge/reference/rest)


### PR DESCRIPTION
## Что изменено

Объединяет пункты 1–3 утренней сводки в один тематический PR.

### WebMCP / Agentic Web

- обновлён материал `docs/info/ai/agentic-web.md`;
- добавлены `getTools()`, `executeTool()` и `toolchange`;
- показана отмена регистрации и выполнения через `AbortSignal`;
- добавлено изменение lifecycle начиная с Chrome 153;
- добавлен рабочий cross-origin пример с `allow="tools"`, `exposedTo` и `fromOrigins`;
- добавлен threat model для embedded widgets и проверка `tool.origin`.

### Chrome DevTools MCP

- добавлен рецепт `docs/hosting/testing/chrome-devtools-mcp.md`;
- описана установка для Codex, Gemini CLI, Claude Code и generic MCP client;
- добавлены prompts для Storybook, VuePress/SEO Recipes и audit-only production режима;
- добавлены console/network checklist, формат отчёта и место runtime-аудита в release process;
- разобран кейс CyberAgent: 32 компонента и 236 stories.

### Google Developer Knowledge

- добавлен материал `docs/info/ai/google-developer-knowledge.md`;
- описаны REST API, remote MCP, `search_documents`, `get_documents` и `answer_query`;
- добавлены `relevanceScore`, filters, получение полного Markdown-документа и gcloud alpha commands;
- добавлен pipeline для подготовки материалов SEO Recipes сначала по официальному corpus;
- обновлён индекс `docs/info/ai/README.md`.

## Источники

- https://developer.chrome.com/docs/ai/webmcp/imperative-api
- https://developer.chrome.com/docs/ai/webmcp/security
- https://developer.chrome.com/docs/devtools/agents/get-started
- https://developer.chrome.com/blog/autofix-runtime-devtools-mcp
- https://developers.google.com/knowledge/release-notes
- https://developers.google.com/knowledge/mcp
- https://developers.google.com/knowledge/howto

## Verification

- [x] YAML-frontmatter разобран локально без ошибок
- [x] Markdown code fences сбалансированы
- [x] Новые относительные ссылки разрешаются
- [x] Git blob SHA файлов в ветке совпадают с локально проверенными файлами
- [x] Diff ограничен четырьмя ожидаемыми Markdown-файлами
- [ ] `npm run docs:build` — ожидается в PR/Vercel CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ichinya/seo_recipes/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->